### PR TITLE
Bubble up support for hyper's optional SSL in Cargo.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,13 @@ name = "jsonrpc"
 path = "src/lib.rs"
 
 [dependencies]
-hyper = "0.6"
 serde = "0.6"
 strason = "0.3"
 
+[dependencies.hyper]
+version = "0.6"
+default-features = false
 
+[features]
+default = ["ssl"]
+ssl = ["hyper/ssl"]


### PR DESCRIPTION
I have no idea what I am doing here but it makes it go.