### PR TITLE
Switch strason to serde_json; update hyper to 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.17.0
+  - 1.21.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 serde = "1"
 serde_derive = "1"
-strason = "0.4"
+serde_json = "1"
 
 [dependencies.hyper]
 version = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/apoelstra/rust-jsonrpc/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,5 @@ path = "src/lib.rs"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+hyper = "0.10"
 
-[dependencies.hyper]
-version = "0.9"
-default-features = false
-
-[features]
-default = []
-ssl = ["hyper/ssl"]

--- a/README.md
+++ b/README.md
@@ -4,72 +4,25 @@
 
 Rudimentary support for sending JSONRPC 2.0 requests and receiving responses.
 
-## Serde Support
-
-This includes a of macro to enable serialization/deserialization of
-structures without using stable or nightly. They can be used as follows:
-```rust
-#[macro_use] extern crate jsonrpc;
-extern crate serde;
-
-struct MyStruct {
-    elem1: bool,
-    elem2: String,
-    elem3: Vec<usize>
-}
-serde_struct_impl!(MyStruct, elem1, elem2, elem3 <- "alternate name for elem3");
-```
-When encoding, the field will be given its alternate name if one is
-present. Otherwise the ordinary name is used.
-
-There is also a variant of this for enums representing structures that might
-have one of a few possible forms. For example
-```
-struct Variant1 {
-    success: bool,
-    success_message: String
-}
-
-struct Variant2 {
-    success: bool,
-    errors: Vec<String>
-}
-
-enum Reply {
-    Good(Variant1),
-    Bad(Variant2)
-}
-serde_struct_enum_impl!(Reply,
-    Good, Variant1, success, success_message;
-    Bad, Variant2, success, errors
-);
-```
-Note that this macro works by returning the first variant for which all
-fields are present. This means that if one variant is a superset of another,
-the larger one should be given first to the macro to prevent the smaller
-from always being matched.
-
-## JSONRPC
-
 To send a request which should retrieve the above structure, consider the following
 example code
 
 ```rust
-#[macro_use] extern crate jsonrpc;
+extern crate jsonrpc;
 extern crate serde;
+#[macro_use] extern crate serde_derive;
 
+#[derive(Deserialize)]
 struct MyStruct {
     elem1: bool,
     elem2: String,
     elem3: Vec<usize>
 }
 
-serde_struct_impl!(MyStruct, elem1, elem2, elem3);
-
 fn main() {
     // The two Nones are for user/pass for authentication
-    let mut client = jsonrpc::client::Client::new("example.org", None, None);
-    let request = client.build_request("getmystruct", vec![]);
+    let mut client = jsonrpc::client::Client::new("example.org".to_owned(), None, None);
+    let request = client.build_request("getmystruct".to_owned(), vec![]);
     match client.send_request(&request).and_then(|res| res.into_result::<MyStruct>()) {
         Ok(mystruct) => // Ok!
         Err(e) => // Not so much.


### PR DESCRIPTION
Some notes justifying the choice of hyper 0.10 while the latest is 0.12, from https://github.com/apoelstra/rust-jsonrpc/pull/7

hyper 0.11 introduced a lot of complex asynchronous tokio stuff that we don't need; 0.12 made it optional (yay!) but didn't replace it with anything, meaning that we'd have to implement a lot of connection management ourselves. So our choices with hyper 0.12 are either to use the default options, bringing us up to 45 deps (lots of which are quickly-changing tokio), or re-implement a lot of old-hyper on our own.

With that in mind I'm simply going to upgrade from hyper 0.9 to 0.10; the main changes there are dropping SSL and supporting code, dropping cookie and some supporting code, fixing this security vuln which did not affect rust-jsonrpc hyperium/hyper@2603d78 , and various bugfixes/perf improvements.