### PR TITLE
Some ideas for improvement

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -25,6 +25,7 @@ use std::sync::{Arc, Mutex};
 use hyper;
 use hyper::client::Client as HyperClient;
 use hyper::header::{Authorization, Basic, Headers};
+use serde;
 use serde_json;
 
 use super::{Request, Response};
@@ -61,8 +62,7 @@ impl Client {
         args: &[serde_json::value::Value],
     ) -> Result<T, Error> {
         let request = self.build_request(rpc_name, args);
-        let response = self
-            .send_request(&request)?;
+        let response = self.send_request(&request)?;
 
         Ok(response.clone().into_result()?)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -64,7 +64,7 @@ impl Client {
         let request = self.build_request(rpc_name, args);
         let response = self.send_request(&request)?;
 
-        Ok(response.clone().into_result()?)
+        Ok(response.into_result()?)
     }
 
     /// Sends a request to a client

--- a/src/client.rs
+++ b/src/client.rs
@@ -126,7 +126,11 @@ impl Client {
     }
 
     /// Builds a request
-    pub fn build_request<'a>(&self, name: &'a str, params: &'a [serde_json::Value]) -> Request<'a> {
+    pub fn build_request<'a, 'b>(
+        &self,
+        name: &'a str,
+        params: &'b [serde_json::Value],
+    ) -> Request<'a, 'b> {
         let mut nonce = self.nonce.lock().unwrap();
         *nonce += 1;
         Request {

--- a/src/client.rs
+++ b/src/client.rs
@@ -54,6 +54,19 @@ impl Client {
         }
     }
 
+    /// Make a request and deserialize the response
+    pub fn do_rpc<T: for<'a> serde::de::Deserialize<'a>>(
+        &self,
+        rpc_name: &str,
+        args: &[serde_json::value::Value],
+    ) -> Result<T, Error> {
+        let request = self.build_request(rpc_name, args);
+        let response = self
+            .send_request(&request)?;
+
+        Ok(response.clone().into_result()?)
+    }
+
     /// Sends a request to a client
     pub fn send_request(&self, request: &Request) -> Result<Response, Error> {
         // Build request

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,17 +41,17 @@ pub mod error;
 // Re-export error type
 pub use error::Error;
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 /// A JSONRPC request object
-pub struct Request {
+pub struct Request<'a> {
     /// The name of the RPC call
-    pub method: String,
+    pub method: &'a str,
     /// Parameters to the RPC call
-    pub params: Vec<serde_json::Value>,
+    pub params: &'a [serde_json::Value],
     /// Identifier for this Request, which should appear in the response
     pub id: serde_json::Value,
     /// jsonrpc field, MUST be "2.0"
-    pub jsonrpc: Option<String>,
+    pub jsonrpc: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -108,55 +108,9 @@ impl Response {
 
 #[cfg(test)]
 mod tests {
-    use super::error::RpcError;
-    use super::{Request, Response};
+
+    use super::Response;
     use serde_json;
-
-    #[test]
-    fn request_serialize_round_trip() {
-        let original = Request {
-            method: "test".to_owned(),
-            params: vec![
-                serde_json::Value::Null,
-                From::from(false),
-                From::from(true),
-                From::from("test2"),
-            ],
-            id: From::from("69"),
-            jsonrpc: Some(String::from("2.0")),
-        };
-
-        let ser = serde_json::to_vec(&original).unwrap();
-        let des = serde_json::from_slice(&ser).unwrap();
-
-        assert_eq!(original, des);
-    }
-
-    #[test]
-    fn response_serialize_round_trip() {
-        let original_err = RpcError {
-            code: -77,
-            message: "test4".to_owned(),
-            data: Some(From::from(true)),
-        };
-
-        let original = Response {
-            result: Some(From::<Vec<serde_json::Value>>::from(vec![
-                serde_json::Value::Null,
-                From::from(false),
-                From::from(true),
-                From::from("test2"),
-            ])),
-            error: Some(original_err),
-            id: From::from(101),
-            jsonrpc: Some(String::from("2.0")),
-        };
-
-        let ser = serde_json::to_vec(&original).unwrap();
-        let des = serde_json::from_slice(&ser).unwrap();
-
-        assert_eq!(original, des);
-    }
 
     #[test]
     fn response_is_none() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,11 +43,11 @@ pub use error::Error;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 /// A JSONRPC request object
-pub struct Request<'a> {
+pub struct Request<'a, 'b> {
     /// The name of the RPC call
     pub method: &'a str,
     /// Parameters to the RPC call
-    pub params: &'a [serde_json::Value],
+    pub params: &'b [serde_json::Value],
     /// Identifier for this Request, which should appear in the response
     pub id: serde_json::Value,
     /// jsonrpc field, MUST be "2.0"


### PR DESCRIPTION
While `Request` and `Response` might be useful, for a lot of use-cases they are just an implementation detail, that just gets in the way. I was wondering if they could be made non-private altogether, but I guess for some advanced uses, they might be necessary.

So the first patch makes some allocation savings, and second add a convenience function that allows forgetting that `Response` and `Request` exist at all. First patch have a longer commit explaining more about what's going on.