### PR TITLE
Support JSON-RPC batching

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,14 @@ pub enum Error {
     NonceMismatch,
     /// Response to a request had a jsonrpc field other than "2.0"
     VersionMismatch,
+    /// Batches can't be empty
+    EmptyBatch,
+    /// Too many responses returned in batch
+    WrongBatchResponseSize,
+    /// Batch response contained a duplicate ID
+    BatchDuplicateResponseId(serde_json::Value),
+    /// Batch response contained an ID that didn't correspond to any request ID
+    WrongBatchResponseId(serde_json::Value),
 }
 
 impl From<serde_json::Error> for Error {
@@ -63,6 +71,10 @@ impl fmt::Display for Error {
             Error::Json(ref e) => write!(f, "JSON decode error: {}", e),
             Error::Hyper(ref e) => write!(f, "Hyper error: {}", e),
             Error::Rpc(ref r) => write!(f, "RPC error response: {:?}", r),
+            Error::BatchDuplicateResponseId(ref v) => {
+                write!(f, "duplicate RPC batch response ID: {}", v)
+            }
+            Error::WrongBatchResponseId(ref v) => write!(f, "wrong RPC batch response ID: {}", v),
             _ => f.write_str(error::Error::description(self)),
         }
     }
@@ -76,6 +88,12 @@ impl error::Error for Error {
             Error::Rpc(_) => "RPC error response",
             Error::NonceMismatch => "Nonce of response did not match nonce of request",
             Error::VersionMismatch => "`jsonrpc` field set to non-\"2.0\"",
+            Error::EmptyBatch => "batches can't be empty",
+            Error::WrongBatchResponseSize => "too many responses returned in batch",
+            Error::BatchDuplicateResponseId(_) => "batch response contained a duplicate ID",
+            Error::WrongBatchResponseId(_) => {
+                "batch response contained an ID that didn't correspond to any request ID"
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,4 +159,18 @@ mod tests {
         assert!(recovered1.is_err());
         assert!(recovered2.is_err());
     }
+
+    #[test]
+    fn batch_response() {
+        // from the jsonrpc.org spec example
+        let s = r#"[
+            {"jsonrpc": "2.0", "result": 7, "id": "1"},
+            {"jsonrpc": "2.0", "result": 19, "id": "2"},
+            {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": null},
+            {"jsonrpc": "2.0", "error": {"code": -32601, "message": "Method not found"}, "id": "5"},
+            {"jsonrpc": "2.0", "result": ["hello", 5], "id": "9"}
+        ]"#;
+        let batch_response: Vec<Response> = serde_json::from_str(&s).unwrap();
+        assert_eq!(batch_response.len(), 5);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub extern crate serde_json;
 
 pub mod client;
 pub mod error;
+mod util;
 
 // Re-export error type
 pub use error::Error;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,120 @@
+// Rust JSON-RPC Library
+// Written in 2019 by
+//   Andrew Poelstra <apoelstra@wpsoftware.net>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+use std::hash::{Hash, Hasher};
+
+use serde_json::Value;
+
+/// Newtype around `Value` which allows hashing for use as hashmap keys
+/// This is needed for batch requests.
+///
+/// The reason `Value` does not support `Hash` or `Eq` by itself
+/// is that it supports `f64` values; but for batch requests we
+/// will only be hashing the "id" field of the request/response
+/// pair, which should never need decimal precision and therefore
+/// never use `f64`.
+#[derive(Clone, PartialEq, Debug)]
+pub struct HashableValue<'a>(pub &'a Value);
+
+impl<'a> Eq for HashableValue<'a> {}
+
+impl<'a> Hash for HashableValue<'a> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match *self.0 {
+            Value::Null => "null".hash(state),
+            Value::Bool(false) => "false".hash(state),
+            Value::Bool(true) => "true".hash(state),
+            Value::Number(ref n) => {
+                "number".hash(state);
+                if let Some(n) = n.as_i64() {
+                    n.hash(state);
+                } else if let Some(n) = n.as_u64() {
+                    n.hash(state);
+                } else {
+                    n.to_string().hash(state);
+                }
+            },
+            Value::String(ref s) => {
+                "string".hash(state);
+                s.hash(state);
+            },
+            Value::Array(ref v) => {
+                "array".hash(state);
+                v.len().hash(state);
+                for obj in v {
+                    HashableValue(obj).hash(state);
+                }
+            },
+            Value::Object(ref m) => {
+                "object".hash(state);
+                m.len().hash(state);
+                for (key, val) in m {
+                    key.hash(state);
+                    HashableValue(val).hash(state);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn hash_value() {
+        let val = Value::from_str("null").unwrap();
+        let val = HashableValue(&val);
+
+        let t = Value::from_str("true").unwrap();
+        let t = HashableValue(&t);
+
+        let f = Value::from_str("false").unwrap();
+        let f = HashableValue(&f);
+
+        let ns = Value::from_str("[0, -0, 123.4567, -100000000]").unwrap();
+        let ns = HashableValue(&ns);
+
+        let m = Value::from_str("{ \"field\": 0, \"field\": -0 }").unwrap();
+        let m = HashableValue(&m);
+
+        let mut coll = HashSet::new();
+
+        assert!(!coll.contains(&val));
+        coll.insert(val.clone());
+        assert!(coll.contains(&val));
+
+        assert!(!coll.contains(&t));
+        assert!(!coll.contains(&f));
+        coll.insert(t.clone());
+        assert!(coll.contains(&t));
+        assert!(!coll.contains(&f));
+        coll.insert(f.clone());
+        assert!(coll.contains(&t));
+        assert!(coll.contains(&f));
+
+        assert!(!coll.contains(&ns));
+        coll.insert(ns.clone());
+        assert!(coll.contains(&ns));
+
+        assert!(!coll.contains(&m));
+        coll.insert(m.clone());
+        assert!(coll.contains(&m));
+    }
+}
+
+


### PR DESCRIPTION
One drawback about this implementation is that the responses get lost when a batch error is produced. If retaining those is desired, suggestions are welcome.