### PR TITLE
Fixes to the Transport impl

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -18,6 +18,7 @@
 //! and parsing responses
 //!
 
+use std::fmt;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::atomic;
@@ -30,32 +31,32 @@ use super::{Request, Response};
 use util::HashableValue;
 use error::Error;
 
-/// An interface for a transport over which to use the JSONRPC protocol.
-pub trait Transport {
-    /// The Error type for this transport.
-    /// Errors will get converted into Box<std::error::Error> so the
-    /// type here is not use any further.
-    type Err: ::std::error::Error;
 
-    /// Make an RPC call over the transport.
-    fn call<R>(&self, impl serde::Serialize) -> Result<R, Self::Err>
-        where R: for<'a> serde::de::Deserialize<'a>;
+/// An interface for a transport over which to use the JSONRPC protocol.
+pub trait Transport: Send + Sync + 'static {
+    /// Send an RPC request over the transport.
+    fn send_request(&self, Request) -> Result<Response, Error>;
+    /// Send a batch of RPC requests over the transport.
+    fn send_batch(&self, &[Request]) -> Result<Vec<Response>, Error>;
+    /// Format the target of this transport.
+    /// I.e. the URL/socket/...
+    fn fmt_target(&self, f: &mut fmt::Formatter) -> fmt::Result;
 }
 
 /// A JSON-RPC client.
 ///
 /// Create a new Client using one of the transport-specific constructors:
 /// - [Client::simple_http] for the built-in bare-minimum HTTP transport
-pub struct Client<T: Transport> {
-    transport: T,
+pub struct Client {
+    pub(crate) transport: Box<dyn Transport>,
     nonce: atomic::AtomicUsize,
 }
 
-impl<T: Transport + 'static> Client<T> {
+impl Client {
     /// Creates a new client with the given transport.
-    pub fn with_transport(transport: T) -> Client<T> {
+    pub fn with_transport<T: Transport>(transport: T) -> Client {
         Client {
-            transport: transport,
+            transport: Box::new(transport),
             nonce: atomic::AtomicUsize::new(1),
         }
     }
@@ -77,8 +78,7 @@ impl<T: Transport + 'static> Client<T> {
 
     /// Sends a request to a client
     pub fn send_request(&self, request: Request) -> Result<Response, Error> {
-        let res: Result<Response, _> = self.transport.call(&request);
-        res.map_err(|e| Error::Transport(e.into()))
+        self.transport.send_request(request)
     }
 
     /// Sends a batch of requests to the client.  The return vector holds the response
@@ -93,8 +93,7 @@ impl<T: Transport + 'static> Client<T> {
 
         // If the request body is invalid JSON, the response is a single response object.
         // We ignore this case since we are confident we are producing valid JSON.
-        let responses: Vec<Response> = self.transport.call(requests)
-            .map_err(|e| Error::Transport(e.into()))?;
+        let responses = self.transport.send_batch(requests)?;
         if responses.len() > requests.len() {
             return Err(Error::WrongBatchResponseSize);
         }
@@ -144,21 +143,24 @@ impl<T: Transport + 'static> Client<T> {
     }
 }
 
+impl fmt::Debug for ::Client {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "jsonrpc::Client(")?;
+        self.transport.fmt_target(f)?;
+        write!(f, ")")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{io, sync};
-    use serde;
+    use std::sync;
 
     struct DummyTransport;
     impl Transport for DummyTransport {
-        type Err = io::Error;
-
-        fn call<R>(&self, _req: impl serde::Serialize) -> Result<R, Self::Err>
-            where R: for<'a> serde::de::Deserialize<'a>
-        {
-            Err(io::Error::new(io::ErrorKind::Other, ""))
-        }
+        fn send_request(&self, _: Request) -> Result<Response, Error> { Err(Error::NonceMismatch) }
+        fn send_batch(&self, _: &[Request]) -> Result<Vec<Response>, Error> { Ok(vec![]) }
+        fn fmt_target(&self, f: &mut fmt::Formatter) -> fmt::Result { Ok(()) }
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -61,7 +61,10 @@ impl Client {
         }
     }
 
-    /// Builds a request
+    /// Builds a request.
+    ///
+    /// To construct the arguments, one can use one of the shorthand methods
+    /// [jsonrpc::arg] or [jsonrpc::try_arg].
     pub fn build_request<'a>(
         &self,
         method: &'a str,
@@ -122,7 +125,10 @@ impl Client {
         Ok(results)
     }
 
-    /// Make a request and deserialize the response
+    /// Make a request and deserialize the response.
+    ///
+    /// To construct the arguments, one can use one of the shorthand methods
+    /// [jsonrpc::arg] or [jsonrpc::try_arg].
     pub fn call<R: for<'a> serde::de::Deserialize<'a>>(
         &self,
         method: &str,

--- a/src/client.rs
+++ b/src/client.rs
@@ -24,8 +24,8 @@ use std::collections::HashMap;
 use std::sync::atomic;
 
 use serde;
-// use base64;
 use serde_json;
+use serde_json::value::RawValue;
 
 use super::{Request, Response};
 use util::HashableValue;
@@ -65,7 +65,7 @@ impl Client {
     pub fn build_request<'a>(
         &self,
         method: &'a str,
-        params: &'a [Box<serde_json::value::RawValue>],
+        params: &'a [Box<RawValue>],
     ) -> Request<'a> {
         let nonce = self.nonce.fetch_add(1, atomic::Ordering::Relaxed);
         Request {
@@ -126,7 +126,7 @@ impl Client {
     pub fn call<R: for<'a> serde::de::Deserialize<'a>>(
         &self,
         method: &str,
-        args: &[Box<serde_json::value::RawValue>],
+        args: &[Box<RawValue>],
     ) -> Result<R, Error> {
         let request = self.build_request(method, args);
         let id = request.id.clone();

--- a/src/client.rs
+++ b/src/client.rs
@@ -166,7 +166,7 @@ mod tests {
     impl Transport for DummyTransport {
         fn send_request(&self, _: Request) -> Result<Response, Error> { Err(Error::NonceMismatch) }
         fn send_batch(&self, _: &[Request]) -> Result<Vec<Response>, Error> { Ok(vec![]) }
-        fn fmt_target(&self, f: &mut fmt::Formatter) -> fmt::Result { Ok(()) }
+        fn fmt_target(&self, _: &mut fmt::Formatter) -> fmt::Result { Ok(()) }
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ use Response;
 #[derive(Debug)]
 pub enum Error {
     /// A transport error
-    Transport(Box<error::Error>),
+    Transport(Box<dyn error::Error + Send + Sync>),
     /// Json error
     Json(serde_json::Error),
     /// Error response

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,24 @@ pub use client::{Client, Transport};
 
 use serde_json::value::RawValue;
 
+/// Shorthand method to convert an argument into a [Box<serde_json::value::RawValue>].
+/// Since serializers rarely fail, it's probably easier to use [arg] instead.
+pub fn try_arg<T: serde::Serialize>(arg: T) -> Result<Box<RawValue>, serde_json::Error> {
+    RawValue::from_string(serde_json::to_string(&arg)?)
+}
+
+/// Shorthand method to convert an argument into a [Box<serde_json::value::RawValue>].
+///
+/// This conversion should not fail, so to avoid returning a [Result],
+/// in case of an error, the error is serialized as the return value.
+pub fn arg<T: serde::Serialize>(arg: T) -> Box<RawValue> {
+    match try_arg(arg) {
+        Ok(v) => v,
+        Err(e) => RawValue::from_string(format!("<<ERROR SERIALIZING ARGUMENT: {}>>", e))
+            .unwrap_or(RawValue::from_string("<<ERROR SERIALIZING ARGUMENT>>".to_owned()).unwrap()),
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 /// A JSONRPC request object
 pub struct Request<'a> {
@@ -176,5 +194,30 @@ mod tests {
         ]"#;
         let batch_response: Vec<Response> = serde_json::from_str(&s).unwrap();
         assert_eq!(batch_response.len(), 5);
+    }
+
+    #[test]
+    fn test_arg() {
+        macro_rules! test_arg {
+            ($val:expr, $t:ty) => {{
+                let val1: $t = $val;
+                let arg = super::arg(val1.clone());
+                let val2: $t = serde_json::from_str(arg.get()).expect(stringify!($val));
+                assert_eq!(val1, val2, "failed test for {}", stringify!($val));
+            }}
+        }
+
+        test_arg!(true, bool);
+        test_arg!(42, u8);
+        test_arg!(42, usize);
+        test_arg!(42, isize);
+        test_arg!(vec![42, 35], Vec<u8>);
+        test_arg!(String::from("test"), String);
+
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+        struct Test {
+            v: String,
+        }
+        test_arg!(Test { v: String::from("test"), }, Test);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,13 +49,15 @@ pub mod simple_http;
 pub use error::Error;
 pub use client::{Client, Transport};
 
+use serde_json::value::RawValue;
+
 #[derive(Debug, Clone, Serialize)]
 /// A JSONRPC request object
 pub struct Request<'a> {
     /// The name of the RPC call
     pub method: &'a str,
     /// Parameters to the RPC call
-    pub params: &'a [Box<serde_json::value::RawValue>],
+    pub params: &'a [Box<RawValue>],
     /// Identifier for this Request, which should appear in the response
     pub id: serde_json::Value,
     /// jsonrpc field, MUST be "2.0"
@@ -66,7 +68,7 @@ pub struct Request<'a> {
 /// A JSONRPC response object
 pub struct Response {
     /// A result if there is one, or null
-    pub result: Option<Box<serde_json::value::RawValue>>,
+    pub result: Option<Box<RawValue>>,
     /// An error if there is one, or null
     pub error: Option<error::RpcError>,
     /// Identifier for this Request, which should match that of the request

--- a/src/simple_http.rs
+++ b/src/simple_http.rs
@@ -62,7 +62,9 @@ impl SimpleHttpTransport {
         let body = serde_json::to_vec(&req)?;
 
         // Send HTTP request
-        sock.write_all(format!("POST {} HTTP/1.1\r\n", self.path).as_bytes())?;
+        sock.write_all(b"POST ")?;
+        sock.write_all(self.path.as_bytes())?;
+        sock.write_all(b" HTTP/1.1\r\n")?;
         // Write headers
         sock.write_all(b"Content-Type: application/json-rpc\r\n")?;
         sock.write_all(b"Content-Length: ")?;

--- a/src/simple_http.rs
+++ b/src/simple_http.rs
@@ -63,7 +63,7 @@ impl SimpleHttpTransport {
         // Write headers
         sock.write_all(b"Content-Type: application/json-rpc\r\n")?;
         if let Some(ref auth) = self.basic_auth {
-            sock.write_all(b"Authentication: ")?;
+            sock.write_all(b"Authorization: ")?;
             sock.write_all(auth.as_ref())?;
             sock.write_all(b"\r\n")?;
         }

--- a/src/simple_http.rs
+++ b/src/simple_http.rs
@@ -263,6 +263,12 @@ impl Builder {
         self
     }
 
+    /// Add authentication information to the transport using a cookie string ('user:pass')
+    pub fn cookie_auth<S: AsRef<str>>(mut self, cookie: S) -> Self {
+        self.tp.basic_auth = Some(format!("Basic {}", &base64::encode(cookie.as_ref().as_bytes())));
+        self
+    }
+
     /// Builds the final `SimpleHttpTransport`
     pub fn build(self) -> SimpleHttpTransport {
         self.tp


### PR DESCRIPTION
I had a bunch of changes when I noticed https://github.com/apoelstra/rust-jsonrpc/pull/38, so I cherry-picked @darosior's changes on top here.

This makes the Transport into a Box so that our client doesn't need to be generic. Because traits with generic methods are not allowed to be boxed, the trait methods had to be changed to `send_request` and `send_batch` with concrete types.