### PR TITLE
README: 1.29 needs byteorder to be pined, too

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,6 @@ jobs:
           override: true
       - name: Pin serde dependencies if rust 1.29
         if: matrix.toolchain == '1.29.0'
-        run: cargo generate-lockfile --verbose && cargo update --package 'serde_json' --precise '1.0.39' && cargo update --package 'serde_derive' --precise '1.0.98'
+        run: cargo generate-lockfile --verbose && cargo update -p byteorder --precise "1.3.4" && cargo update --package 'serde_json' --precise '1.0.39' && cargo update --package 'serde' --precise '1.0.98' && cargo update --package 'serde_derive' --precise '1.0.98'
       - name: Running tests on ${{ matrix.toolchain }}
         run: cargo test --verbose --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,17 +3,6 @@ on: [push, pull_request]
 name: Continuous integration
 
 jobs:
-  rustfmt_check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            components: rustfmt
-            override: true
-      - run: cargo fmt -- --check
-
   Tests:
     name: Tests
     strategy:
@@ -25,6 +14,7 @@ jobs:
         toolchain:
           - 1.29.0
           - stable
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ In particular,
 For compatibility with older versions of rustc, use the following commands to
 pull your dependencies back down to unbroken versions:
 ```
-cargo update --package 'serde_json' --precise '1.0.39'
-cargo update --package 'serde_derive' --precise '1.0.98'
+cargo +1.29 update -p byteorder --precise "1.3.4"
+cargo +1.29 update --package 'serde_json' --precise '1.0.39'
+cargo +1.29 update --package 'serde' --precise '1.0.98'
+cargo +1.29 update --package 'serde_derive' --precise '1.0.98'
 ```
 
 # Rust JSONRPC Client


### PR DESCRIPTION
However i can't compile master with `1.29` using:
```
cargo clean && cargo +1.29 generate-lockfile --verbose && cargo +1.29  update -p byteorder --precise "1.3.4" && cargo +1.29 update --package 'serde_json' --precise '1.0.39' && cargo +1.29 update --package 'serde_derive' --precise '1.0.98' && cargo +1.29 test
```