### PR TITLE
[API break] Minimal server support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,4 +39,5 @@ jobs:
         if: matrix.toolchain == '1.29.0'
         run: cargo generate-lockfile --verbose && cargo update -p byteorder --precise "1.3.4" && cargo update --package 'serde_json' --precise '1.0.39' && cargo update --package 'serde' --precise '1.0.98' && cargo update --package 'serde_derive' --precise '1.0.98'
       - name: Running tests on ${{ matrix.toolchain }}
+        if: matrix.toolchain != '1.29.0' || matrix.os != 'windows-latest'
         run: cargo test --verbose --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,7 @@ jobs:
         toolchain:
           - 1.29.0
           - stable
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,6 @@ jobs:
           override: true
       - name: Pin serde dependencies if rust 1.29
         if: matrix.toolchain == '1.29.0'
-        run: cargo generate-lockfile --verbose && cargo update --package 'serde_json' --precise '1.0.39' && cargo update --package 'serde_derive' --precise '1.0.98'
+        run: cargo generate-lockfile --verbose && cargo update -p byteorder --precise "1.3.4" && cargo update --package 'serde_json' --precise '1.0.39' && cargo update --package 'serde' --precise '1.0.98' && cargo update --package 'serde_derive' --precise '1.0.98'
       - name: Running tests on ${{ matrix.toolchain }}
         run: cargo test --verbose --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ default = [ "simple_http", "simple_tcp" ]
 simple_http = [ "base64-compat" ]
 # Basic transport over a raw TcpListener
 simple_tcp = []
+# Basic transport over a raw UnixStream
+simple_uds = []
+
 
 [dependencies]
 serde = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ name = "jsonrpc"
 path = "src/lib.rs"
 
 [features]
-default = [ "simple_http" ]
+default = [ "simple_http", "simple_tcp" ]
 # A bare-minimum HTTP transport.
 simple_http = [ "base64-compat" ]
+# Basic transport over a raw TcpListener
+simple_tcp = []
 
 [dependencies]
 serde = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ simple_tcp = []
 # Basic transport over a raw UnixStream
 simple_uds = []
 
+# Activate a third party crate to use UDSs on Windows
+[target.'cfg(windows)'.features]
+simple_uds = ["uds_windows"]
+
 
 [dependencies]
 serde = "1"
@@ -30,4 +34,5 @@ serde_derive = "1"
 serde_json = { version = "1", features = [ "raw_value" ] }
 
 base64-compat = { version = "1.0.0", optional = true }
-
+[target.'cfg(windows)'.dependencies]
+uds_windows = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ In particular,
 For compatibility with older versions of rustc, use the following commands to
 pull your dependencies back down to unbroken versions:
 ```
-cargo update --package 'serde_json' --precise '1.0.39'
-cargo update --package 'serde_derive' --precise '1.0.98'
+cargo +1.29 update -p byteorder --precise "1.3.4"
+cargo +1.29 update --package 'serde_json' --precise '1.0.39'
+cargo +1.29 update --package 'serde' --precise '1.0.98'
+cargo +1.29 update --package 'serde_derive' --precise '1.0.98'
 ```
 
 # Rust JSONRPC Client

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,9 +18,9 @@
 //! and parsing responses
 //!
 
-use std::fmt;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::atomic;
 
 use serde;
@@ -28,9 +28,8 @@ use serde_json;
 use serde_json::value::RawValue;
 
 use super::{Request, Response};
-use util::HashableValue;
 use error::Error;
-
+use util::HashableValue;
 
 /// An interface for a transport over which to use the JSONRPC protocol.
 pub trait Transport: Send + Sync + 'static {
@@ -65,11 +64,7 @@ impl Client {
     ///
     /// To construct the arguments, one can use one of the shorthand methods
     /// [jsonrpc::arg] or [jsonrpc::try_arg].
-    pub fn build_request<'a>(
-        &self,
-        method: &'a str,
-        params: &'a [Box<RawValue>],
-    ) -> Request<'a> {
+    pub fn build_request<'a>(&self, method: &'a str, params: &'a [Box<RawValue>]) -> Request<'a> {
         let nonce = self.nonce.fetch_add(1, atomic::Ordering::Relaxed);
         Request {
             method: method,
@@ -112,9 +107,10 @@ impl Client {
             }
         }
         // Match responses to the requests.
-        let results = requests.into_iter().map(|r| {
-            by_id.remove(&HashableValue(Cow::Borrowed(&r.id)))
-        }).collect();
+        let results = requests
+            .into_iter()
+            .map(|r| by_id.remove(&HashableValue(Cow::Borrowed(&r.id))))
+            .collect();
 
         // Since we're also just producing the first duplicate ID, we can also just produce the
         // first incorrect ID in case there are multiple.
@@ -164,9 +160,15 @@ mod tests {
 
     struct DummyTransport;
     impl Transport for DummyTransport {
-        fn send_request(&self, _: Request) -> Result<Response, Error> { Err(Error::NonceMismatch) }
-        fn send_batch(&self, _: &[Request]) -> Result<Vec<Response>, Error> { Ok(vec![]) }
-        fn fmt_target(&self, _: &mut fmt::Formatter) -> fmt::Result { Ok(()) }
+        fn send_request(&self, _: Request) -> Result<Response, Error> {
+            Err(Error::NonceMismatch)
+        }
+        fn send_batch(&self, _: &[Request]) -> Result<Vec<Response>, Error> {
+            Ok(vec![])
+        }
+        fn fmt_target(&self, _: &mut fmt::Formatter) -> fmt::Result {
+            Ok(())
+        }
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -64,13 +64,13 @@ impl Client {
     ///
     /// To construct the arguments, one can use one of the shorthand methods
     /// [jsonrpc::arg] or [jsonrpc::try_arg].
-    pub fn build_request<'a>(&self, method: &'a str, params: &'a [Box<RawValue>]) -> Request<'a> {
+    pub fn build_request<'a>(&self, method: &'a str, params: serde_json::Value) -> Request<'a> {
         let nonce = self.nonce.fetch_add(1, atomic::Ordering::Relaxed);
         Request {
-            method: method,
+            method: method.into(),
             params: params,
             id: serde_json::Value::from(nonce),
-            jsonrpc: Some("2.0"),
+            jsonrpc: Some("2.0".into()),
         }
     }
 
@@ -128,7 +128,7 @@ impl Client {
     pub fn call<R: for<'a> serde::de::Deserialize<'a>>(
         &self,
         method: &str,
-        args: &[Box<RawValue>],
+        args: serde_json::Value,
     ) -> Result<R, Error> {
         let request = self.build_request(method, args);
         let id = request.id.clone();
@@ -175,9 +175,9 @@ mod tests {
     fn sanity() {
         let client = Client::with_transport(DummyTransport);
         assert_eq!(client.nonce.load(sync::atomic::Ordering::Relaxed), 1);
-        let req1 = client.build_request("test", &[]);
+        let req1 = client.build_request("test", serde_json::Value::Array(vec![]));
         assert_eq!(client.nonce.load(sync::atomic::Ordering::Relaxed), 2);
-        let req2 = client.build_request("test", &[]);
+        let req2 = client.build_request("test", serde_json::Value::Array(vec![]));
         assert_eq!(client.nonce.load(sync::atomic::Ordering::Relaxed), 3);
         assert!(req1.id != req2.id);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -135,7 +135,10 @@ pub struct RpcError {
 }
 
 /// Create a standard error responses
-pub fn standard_error(code: StandardError, data: Option<Box<serde_json::value::RawValue>>) -> RpcError {
+pub fn standard_error(
+    code: StandardError,
+    data: Option<Box<serde_json::value::RawValue>>,
+) -> RpcError {
     match code {
         StandardError::ParseError => RpcError {
             code: -32700,
@@ -172,9 +175,10 @@ pub fn result_to_response(
 ) -> Response {
     match result {
         Ok(data) => Response {
-            result: Some(serde_json::value::RawValue::from_string(
-                serde_json::to_string(&data).unwrap()
-            ).unwrap()),
+            result: Some(
+                serde_json::value::RawValue::from_string(serde_json::to_string(&data).unwrap())
+                    .unwrap(),
+            ),
             error: None,
             id: id,
             jsonrpc: Some(String::from("2.0")),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,17 +71,17 @@ pub fn arg<T: serde::Serialize>(arg: T) -> Box<RawValue> {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// A JSONRPC request object
 pub struct Request<'a> {
     /// The name of the RPC call
-    pub method: &'a str,
+    pub method: std::borrow::Cow<'a, str>,
     /// Parameters to the RPC call
-    pub params: &'a [Box<RawValue>],
+    pub params: serde_json::Value,
     /// Identifier for this Request, which should appear in the response
     pub id: serde_json::Value,
     /// jsonrpc field, MUST be "2.0"
-    pub jsonrpc: Option<&'a str>,
+    pub jsonrpc: Option<std::borrow::Cow<'a, str>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ pub mod simple_tcp;
 
 #[cfg(feature = "simple_uds")]
 pub mod simple_uds;
+#[cfg(all(windows, feature = "simple_uds"))]
+extern crate uds_windows;
 
 // Re-export error type
 pub use client::{Client, Transport};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ mod util;
 #[cfg(feature = "simple_http")]
 pub mod simple_http;
 
+#[cfg(feature = "simple_tcp")]
+pub mod simple_tcp;
+
 // Re-export error type
 pub use client::{Client, Transport};
 pub use error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@ mod util;
 pub mod simple_http;
 
 // Re-export error type
-pub use error::Error;
 pub use client::{Client, Transport};
+pub use error::Error;
 
 use serde_json::value::RawValue;
 
@@ -198,7 +198,7 @@ mod tests {
                 let arg = super::arg(val1.clone());
                 let val2: $t = serde_json::from_str(arg.get()).expect(stringify!($val));
                 assert_eq!(val1, val2, "failed test for {}", stringify!($val));
-            }}
+            }};
         }
 
         test_arg!(true, bool);
@@ -212,6 +212,11 @@ mod tests {
         struct Test {
             v: String,
         }
-        test_arg!(Test { v: String::from("test"), }, Test);
+        test_arg!(
+            Test {
+                v: String::from("test"),
+            },
+            Test
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@ pub mod simple_http;
 #[cfg(feature = "simple_tcp")]
 pub mod simple_tcp;
 
+#[cfg(feature = "simple_uds")]
+pub mod simple_uds;
+
 // Re-export error type
 pub use client::{Client, Transport};
 pub use error::Error;

--- a/src/simple_tcp.rs
+++ b/src/simple_tcp.rs
@@ -122,8 +122,8 @@ mod tests {
         let server = net::TcpListener::bind(&addr).unwrap();
         let addr = server.local_addr().unwrap();
         let dummy_req = Request {
-            method: "arandommethod",
-            params: &[],
+            method: "arandommethod".into(),
+            params: serde_json::Value::Array(vec![]),
             id: serde_json::Value::Number(4242242.into()),
             jsonrpc: Some("2.0".into()),
         };

--- a/src/simple_tcp.rs
+++ b/src/simple_tcp.rs
@@ -1,0 +1,168 @@
+//! This module implements a synchronous transport over a raw TcpListener.
+
+use std::{fmt, io, net, time};
+
+use serde;
+use serde_json;
+
+use client::Transport;
+use {Request, Response};
+
+/// Error that can occur while using the TCP transport.
+#[derive(Debug)]
+pub enum Error {
+    /// An error occurred on the socket layer
+    SocketError(io::Error),
+    /// We didn't receive a complete response till the deadline ran out
+    Timeout,
+    /// JSON parsing error.
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            Error::SocketError(ref e) => write!(f, "Couldn't connect to host: {}", e),
+            Error::Timeout => f.write_str("Didn't receive response data in time, timed out."),
+            Error::Json(ref e) => write!(f, "JSON error: {}", e),
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::SocketError(e)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Error::Json(e)
+    }
+}
+
+impl From<Error> for ::Error {
+    fn from(e: Error) -> ::Error {
+        match e {
+            Error::Json(e) => ::Error::Json(e),
+            e => ::Error::Transport(Box::new(e)),
+        }
+    }
+}
+
+impl ::std::error::Error for Error {}
+
+/// Simple synchronous TCP transport.
+#[derive(Debug, Clone)]
+pub struct TcpTransport {
+    /// The internet socket address to connect to
+    pub addr: net::SocketAddr,
+    /// The read and write timeout to use for this connection
+    pub timeout: Option<time::Duration>,
+}
+
+impl TcpTransport {
+    /// Create a new TcpTransport without timeouts
+    pub fn new(addr: net::SocketAddr) -> TcpTransport {
+        TcpTransport {
+            addr,
+            timeout: None,
+        }
+    }
+
+    fn request<R>(&self, req: impl serde::Serialize) -> Result<R, Error>
+    where
+        R: for<'a> serde::de::Deserialize<'a>,
+    {
+        let mut sock = net::TcpStream::connect(&self.addr)?;
+        sock.set_read_timeout(self.timeout)?;
+        sock.set_write_timeout(self.timeout)?;
+
+        serde_json::to_writer(&mut sock, &req)?;
+
+        // NOTE: we don't check the id there, so it *must* be synchronous
+        let resp: R = serde_json::Deserializer::from_reader(&mut sock)
+            .into_iter()
+            .next()
+            .ok_or(Error::Timeout)??;
+        Ok(resp)
+    }
+}
+
+impl Transport for TcpTransport {
+    fn send_request(&self, req: Request) -> Result<Response, ::Error> {
+        Ok(self.request(req)?)
+    }
+
+    fn send_batch(&self, reqs: &[Request]) -> Result<Vec<Response>, ::Error> {
+        Ok(self.request(reqs)?)
+    }
+
+    fn fmt_target(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.addr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Read, Write},
+        thread,
+    };
+
+    use super::*;
+    use Client;
+
+    // Test a dummy request / response over a raw TCP transport
+    #[test]
+    fn sanity_check_tcp_transport() {
+        let addr: net::SocketAddr =
+            net::SocketAddrV4::new(net::Ipv4Addr::new(127, 0, 0, 1), 0).into();
+        let server = net::TcpListener::bind(&addr).unwrap();
+        let addr = server.local_addr().unwrap();
+        let dummy_req = Request {
+            method: "arandommethod",
+            params: &[],
+            id: serde_json::Value::Number(4242242.into()),
+            jsonrpc: Some("2.0".into()),
+        };
+        let dummy_req_ser = serde_json::to_vec(&dummy_req).unwrap();
+        let dummy_resp = Response {
+            result: None,
+            error: None,
+            id: serde_json::Value::Number(4242242.into()),
+            jsonrpc: Some("2.0".into()),
+        };
+        let dummy_resp_ser = serde_json::to_vec(&dummy_resp).unwrap();
+
+        let client_thread = thread::spawn(move || {
+            let transport = TcpTransport::new(addr);
+            let client = Client::with_transport(transport);
+
+            loop {
+                match client.send_request(dummy_req.clone()) {
+                    Ok(resp) => return resp,
+                    Err(e) => {
+                        // Print so should it fail it can be debugged with --nocapture
+                        eprintln!("Error while sending request: '{:?}'", e);
+                        thread::sleep(time::Duration::from_millis(100));
+                    }
+                }
+            }
+        });
+
+        let (mut stream, _) = server.accept().unwrap();
+        stream.set_read_timeout(Some(time::Duration::from_secs(5))).unwrap();
+        let mut recv_req = vec![0; dummy_req_ser.len()];
+        let mut read = 0;
+        while read < dummy_req_ser.len() {
+            read += stream.read(&mut recv_req[read..]).unwrap();
+        }
+        assert_eq!(recv_req, dummy_req_ser);
+
+        stream.write(&dummy_resp_ser).unwrap();
+        stream.flush().unwrap();
+        let recv_resp = client_thread.join().unwrap();
+        assert_eq!(serde_json::to_vec(&recv_resp).unwrap(), dummy_resp_ser);
+    }
+}

--- a/src/simple_uds.rs
+++ b/src/simple_uds.rs
@@ -133,8 +133,8 @@ mod tests {
 
         let server = UnixListener::bind(&socket_path).unwrap();
         let dummy_req = Request {
-            method: "getinfo",
-            params: &[],
+            method: "getinfo".into(),
+            params: serde_json::Value::Array(vec![]),
             id: serde_json::Value::Number(111.into()),
             jsonrpc: Some("2.0".into()),
         };

--- a/src/simple_uds.rs
+++ b/src/simple_uds.rs
@@ -1,6 +1,10 @@
 //! This module implements a synchronous transport over a raw TcpListener.
 
+#[cfg(not(windows))]
 use std::os::unix::net::UnixStream;
+#[cfg(windows)]
+use uds_windows::UnixStream;
+
 use std::{fmt, io, path, time};
 
 use serde;
@@ -106,10 +110,14 @@ impl Transport for UdsTransport {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(windows))]
+    use std::os::unix::net::UnixListener;
+    #[cfg(windows)]
+    use uds_windows::UnixListener;
+
     use std::{
         fs,
         io::{Read, Write},
-        os::unix::net::UnixListener,
         thread,
     };
 

--- a/src/simple_uds.rs
+++ b/src/simple_uds.rs
@@ -1,7 +1,7 @@
-//! This module implements a synchronous transport over a raw TcpListener. Note that
-//! it does not handle TCP over Unix Domain Sockets, see `simple_uds` for this.
+//! This module implements a synchronous transport over a raw TcpListener.
 
-use std::{fmt, io, net, time};
+use std::os::unix::net::UnixStream;
+use std::{fmt, io, path, time};
 
 use serde;
 use serde_json;
@@ -9,7 +9,7 @@ use serde_json;
 use client::Transport;
 use {Request, Response};
 
-/// Error that can occur while using the TCP transport.
+/// Error that can occur while using the UDS transport.
 #[derive(Debug)]
 pub enum Error {
     /// An error occurred on the socket layer
@@ -53,20 +53,20 @@ impl From<Error> for ::Error {
 
 impl ::std::error::Error for Error {}
 
-/// Simple synchronous TCP transport.
+/// Simple synchronous UDS transport.
 #[derive(Debug, Clone)]
-pub struct TcpTransport {
-    /// The internet socket address to connect to
-    pub addr: net::SocketAddr,
-    /// The read and write timeout to use for this connection
+pub struct UdsTransport {
+    /// The path to the Unix Domain Socket
+    pub sockpath: path::PathBuf,
+    /// The read and write timeout to use
     pub timeout: Option<time::Duration>,
 }
 
-impl TcpTransport {
-    /// Create a new TcpTransport without timeouts
-    pub fn new(addr: net::SocketAddr) -> TcpTransport {
-        TcpTransport {
-            addr,
+impl UdsTransport {
+    /// Create a new UdsTransport without timeouts to use
+    pub fn new<P: AsRef<path::Path>>(sockpath: P) -> UdsTransport {
+        UdsTransport {
+            sockpath: sockpath.as_ref().to_path_buf(),
             timeout: None,
         }
     }
@@ -75,7 +75,7 @@ impl TcpTransport {
     where
         R: for<'a> serde::de::Deserialize<'a>,
     {
-        let mut sock = net::TcpStream::connect(&self.addr)?;
+        let mut sock = UnixStream::connect(&self.sockpath)?;
         sock.set_read_timeout(self.timeout)?;
         sock.set_write_timeout(self.timeout)?;
 
@@ -90,7 +90,7 @@ impl TcpTransport {
     }
 }
 
-impl Transport for TcpTransport {
+impl Transport for UdsTransport {
     fn send_request(&self, req: Request) -> Result<Response, ::Error> {
         Ok(self.request(req)?)
     }
@@ -100,44 +100,48 @@ impl Transport for TcpTransport {
     }
 
     fn fmt_target(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.addr)
+        write!(f, "{}", self.sockpath.to_string_lossy())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
+        fs,
         io::{Read, Write},
+        os::unix::net::UnixListener,
         thread,
     };
 
     use super::*;
     use Client;
 
-    // Test a dummy request / response over a raw TCP transport
+    // Test a dummy request / response over an UDS
     #[test]
-    fn sanity_check_tcp_transport() {
-        let addr: net::SocketAddr =
-            net::SocketAddrV4::new(net::Ipv4Addr::new(127, 0, 0, 1), 0).into();
-        let server = net::TcpListener::bind(&addr).unwrap();
-        let addr = server.local_addr().unwrap();
+    fn sanity_check_uds_transport() {
+        let socket_path: path::PathBuf = "uds_scratch.socket".into();
+        // Any leftover?
+        fs::remove_file(&socket_path).unwrap_or_else(|_| ());
+
+        let server = UnixListener::bind(&socket_path).unwrap();
         let dummy_req = Request {
-            method: "arandommethod",
+            method: "getinfo",
             params: &[],
-            id: serde_json::Value::Number(4242242.into()),
+            id: serde_json::Value::Number(111.into()),
             jsonrpc: Some("2.0".into()),
         };
         let dummy_req_ser = serde_json::to_vec(&dummy_req).unwrap();
         let dummy_resp = Response {
             result: None,
             error: None,
-            id: serde_json::Value::Number(4242242.into()),
+            id: serde_json::Value::Number(111.into()),
             jsonrpc: Some("2.0".into()),
         };
         let dummy_resp_ser = serde_json::to_vec(&dummy_resp).unwrap();
 
+        let cli_socket_path = socket_path.clone();
         let client_thread = thread::spawn(move || {
-            let transport = TcpTransport::new(addr);
+            let transport = UdsTransport::new(cli_socket_path);
             let client = Client::with_transport(transport);
 
             loop {
@@ -165,5 +169,9 @@ mod tests {
         stream.flush().unwrap();
         let recv_resp = client_thread.join().unwrap();
         assert_eq!(serde_json::to_vec(&recv_resp).unwrap(), dummy_resp_ser);
+
+        // Clean up
+        drop(server);
+        fs::remove_file(&socket_path).unwrap();
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -45,18 +45,18 @@ impl<'a> Hash for HashableValue<'a> {
                 } else {
                     n.to_string().hash(state);
                 }
-            },
+            }
             Value::String(ref s) => {
                 "string".hash(state);
                 s.hash(state);
-            },
+            }
             Value::Array(ref v) => {
                 "array".hash(state);
                 v.len().hash(state);
                 for obj in v {
                     HashableValue(Cow::Borrowed(obj)).hash(state);
                 }
-            },
+            }
             Value::Object(ref m) => {
                 "object".hash(state);
                 m.len().hash(state);
@@ -82,8 +82,10 @@ mod tests {
         let val = HashableValue(Cow::Owned(Value::from_str("null").unwrap()));
         let t = HashableValue(Cow::Owned(Value::from_str("true").unwrap()));
         let f = HashableValue(Cow::Owned(Value::from_str("false").unwrap()));
-        let ns = HashableValue(Cow::Owned(Value::from_str("[0, -0, 123.4567, -100000000]").unwrap()));
-        let m = HashableValue(Cow::Owned(Value::from_str("{ \"field\": 0, \"field\": -0 }").unwrap()));
+        let ns =
+            HashableValue(Cow::Owned(Value::from_str("[0, -0, 123.4567, -100000000]").unwrap()));
+        let m =
+            HashableValue(Cow::Owned(Value::from_str("{ \"field\": 0, \"field\": -0 }").unwrap()));
 
         let mut coll = HashSet::new();
 
@@ -109,5 +111,3 @@ mod tests {
         assert!(coll.contains(&m));
     }
 }
-
-


### PR DESCRIPTION
Based on #42 , this implements a basic support for the server side of JSONRPC by allowing to `Deserialize` the `Request`s. I hacked around with the addition of a `ServerTransport` too but it ends up into really restricting the caller. Opening this to alreaady get feedback on the minimal implementation and maybe to start discussing the design of a more integrated support (for example having a `Server` that reads `Request`s from a `Transport`, calls a callback, then writes the `Response` to the `Transport`).