### PR TITLE
simple_http: Send the `Connection: Close` header

### DIFF
--- a/src/simple_http.rs
+++ b/src/simple_http.rs
@@ -69,6 +69,7 @@ impl SimpleHttpTransport {
         sock.write_all(self.path.as_bytes())?;
         sock.write_all(b" HTTP/1.1\r\n")?;
         // Write headers
+        sock.write_all(b"Connection: Close\r\n")?;
         sock.write_all(b"Content-Type: application/json\r\n")?;
         sock.write_all(b"Content-Length: ")?;
         sock.write_all(body.len().to_string().as_bytes())?;


### PR DESCRIPTION
To instruct the server to close the connection after sending the response.

Keeping the connection open can get the client to hang if the server doesn't send a newline following the response. And `simple_http` doesn't support reusing the connection anyway, so no point in enabling keep-alive.

Before this change, I was unable to use `rust-jsonrpc` to communicate with the [Electrum wallet JSONRPC interface](https://electrum.readthedocs.io/en/latest/jsonrpc.html) (this is part of the Electrum *wallet*, different from the Electrum server JSONRPC interface), as it enables keep-alive by default and doesn't send a newline. It works with this PR.