### PR TITLE
Use serde derive feature instead of serde_derive crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ simple_uds = []
 
 
 [dependencies]
-serde = "1"
-serde_derive = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = [ "raw_value" ] }
 
 base64 = { version = "0.13.0", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,7 @@
 use std::{error, fmt};
 
 use serde_json;
+use serde::{Deserialize, Serialize};
 
 use crate::Response;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,9 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
+use serde::{Deserialize, Serialize};
+
 extern crate serde;
-#[macro_use]
-extern crate serde_derive;
 pub extern crate serde_json;
 
 #[cfg(feature = "base64-compat")]
@@ -126,8 +126,8 @@ impl Response {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use super::Response;
     use serde_json::value::RawValue;
 
     #[test]


### PR DESCRIPTION
We do not need to use the `serde_derive` crate, there is a serde feature for this.

This is a replacement for #41 to save you doing it apoelstra.

Fix: #40