### PR TITLE
Release tracking PR - v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.13.0 - 2022-17-21 "Edition 2018 Release"
+
+This release increases the MSRV to 1.41.1, bringing with it a bunch of new language features.
+
+Some highlights:
+
+- The MSRV bump [#58](https://github.com/apoelstra/rust-jsonrpc/pull/58)
+- Add IPv6 support [#63](https://github.com/apoelstra/rust-jsonrpc/pull/63)
+- Remove `serder_derive` dependency [#61](https://github.com/apoelstra/rust-jsonrpc/pull/61)
+
 # 0.12.1 - 2022-01-20
 
 ## Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/apoelstra/rust-jsonrpc/"


### PR DESCRIPTION
Add changelog notes and bump the version to v0.13.0

### TODO

Perhaps we want to merge these PRs before release?
- https://github.com/apoelstra/rust-jsonrpc/pull/64
- https://github.com/apoelstra/rust-jsonrpc/pull/65
