### PR TITLE
Add SOCKS5 Proxy support in http transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ simple_http = [ "base64" ]
 simple_tcp = []
 # Basic transport over a raw UnixStream
 simple_uds = []
+# Enable Socks5 Proxy in transport
+proxy = ["socks"]
 
 
 [dependencies]
@@ -30,3 +32,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = [ "raw_value" ] }
 
 base64 = { version = "0.13.0", optional = true }
+socks = { version = "0.3.4", optional = true}

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-FEATURES="simple_http simple_tcp simple_uds"
+FEATURES="simple_http simple_tcp simple_uds proxy"
 
 cargo --version
 rustc --version


### PR DESCRIPTION
This is an attempt at #57. Which was a request for adding socks5 Proxy support into the http transport. 

This is useful to connect to RPC via Tor.

Summary:
 - Adds a new feature flag `proxy` which does some extra steps to connect the `url` address via a `proxy` address.
 - New fields are added inside `SimpleHttpTransport` which are only visible in `proxy` feature.
 - The first PR contains a refactoring which takes the URL sanity checking logic to its own function. So that it can be used for the `proxy-addr` checking also.
 - New constructor:  Client::http_proxy()
 - Test covering basic behavior.  