### PR TITLE
WIP: try to fix CI on macos

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,14 +6,15 @@ jobs:
   Tests:
     name: Tests
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
         toolchain:
-          - 1.41.1
           - stable
+          - 1.41.1
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Crate
@@ -27,7 +28,7 @@ jobs:
       - name: Running tests on ${{ matrix.toolchain }}
         env:
           DO_FEATURE_MATRIX: true
-        run: cargo test --verbose --all-features
+        run: ./contrib/test.sh
 
   Nightly:
     name: Nightly - Docs + Fmt

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -11,6 +11,15 @@ if cargo --version | grep nightly; then
     NIGHTLY=true
 fi
 
+# On MacOS on 1.41 we get a link failure with syn
+# This is fixed by https://github.com/rust-lang/rust/pull/91604 (I think)
+# but implies that we can't do testing on MacOS for now, at least with 1.41.
+if cargo --version | grep "1\.41\.0"; then
+    if [ "$RUNNER_OS" = "macOS" ]; then
+        exit 0
+    fi
+fi
+
 # Defaults / sanity checks
 cargo build --all
 cargo test --all


### PR DESCRIPTION
It looks like there is some old LLVM/rustc/linker/??? bug that is preventing `syn` from building on MacOS and breaking our CI. This commit just disables it.

cc @tcharding can you pull this commit into #74 and then we'll merge that?