### PR TITLE
Simple HTTP cleanups and followup to #72

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target
 Cargo.lock
 
+fuzz/hfuzz_workspace/
+fuzz/hfuzz_target/

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "jsonrpc-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[features]
+honggfuzz_fuzz = ["honggfuzz"]
+
+[dependencies]
+honggfuzz = { version = "0.5", optional = true, default-features = false }
+jsonrpc = { path = ".." }
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "simple_http"
+path = "fuzz_targets/simple_http.rs"
+

--- a/fuzz/fuzz_targets/simple_http.rs
+++ b/fuzz/fuzz_targets/simple_http.rs
@@ -1,0 +1,60 @@
+
+extern crate jsonrpc;
+
+#[cfg(not(fuzzing))]
+compile_error!("You must set RUSTFLAGS=--cfg=fuzzing to run these test, or run the actual fuzz harness.");
+
+use jsonrpc::Client;
+use jsonrpc::simple_http::SimpleHttpTransport;
+use jsonrpc::simple_http::FUZZ_TCP_SOCK;
+
+use std::io;
+
+fn do_test(data: &[u8]) {
+    *FUZZ_TCP_SOCK.lock().unwrap() = Some(io::Cursor::new(data.to_vec()));
+
+    let t = SimpleHttpTransport::builder()
+        .url("localhost:123").expect("parse url")
+        .auth("", None)
+        .build();
+
+    let client = Client::with_transport(t);
+    let request = client.build_request("uptime", &[]);
+    let _ = client.send_request(request);
+}
+
+#[cfg(feature = "honggfuzz")]
+fn main() {
+    loop {
+        honggfuzz::fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    fn extend_vec_from_hex(hex: &str) -> Vec<u8> {
+        let mut out = vec![];
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn duplicate_crash() {
+        super::do_test(&extend_vec_from_hex("00"));
+    }
+}

--- a/fuzz/travis-fuzz.sh
+++ b/fuzz/travis-fuzz.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# Check that input files are correct Windows file names
+incorrectFilenames=$(find . -type f -name "*,*" -o -name "*:*" -o -name "*<*" -o -name "*>*" -o -name "*|*" -o -name "*\?*" -o -name "*\**" -o -name "*\"*" | wc -l)
+
+if [ ${incorrectFilenames} -gt 0 ]; then
+	echo 'Exiting early due to Windows-incompatible filenames in this tree. If this is happening'
+	echo 'to you on a local run, deleting the `hfuzz_workspace/` directory will probably fix it.'
+	exit 2
+fi
+
+if [ "$1" == "" ]; then
+	TARGETS=fuzz_targets/*
+else
+	TARGETS=fuzz_targets/"$1".rs
+fi
+
+cargo --version
+rustc --version
+
+# Testing
+cargo install --force honggfuzz --no-default-features
+for TARGET in $TARGETS; do
+	echo "Fuzzing target $TARGET"
+	FILENAME=$(basename $TARGET)
+	FILE="${FILENAME%.*}"
+	if [ -d hfuzz_input/$FILE ]; then
+	    HFUZZ_INPUT_ARGS="-f hfuzz_input/$FILE/input"
+	fi
+	HFUZZ_BUILD_ARGS="--features honggfuzz_fuzz" HFUZZ_RUN_ARGS="--run_time 30 --exit_upon_crash -v $HFUZZ_INPUT_ARGS" cargo hfuzz run $FILE
+
+	if [ -f hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT ]; then
+		cat hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT
+		for CASE in hfuzz_workspace/$FILE/SIG*; do
+			cat $CASE | xxd -p -c1000
+		done
+		exit 1
+	fi
+done

--- a/src/simple_http.rs
+++ b/src/simple_http.rs
@@ -93,6 +93,9 @@ impl Default for SimpleHttpTransport {
                 DEFAULT_PORT,
             ),
             path: "/".to_owned(),
+            #[cfg(fuzzing)]
+            timeout: Duration::from_millis(1),
+            #[cfg(not(fuzzing))]
             timeout: Duration::from_secs(15),
             basic_auth: None,
             #[cfg(feature = "proxy")]


### PR DESCRIPTION
Tightens the mutex lifetime to improve performance. Basically we read all the data into a buffer and then unlock the mutex ASAP. We could be a bit more memory-efficient by using `serde_json::from_reader` to parse directly from the socket, but (a) that would make it harder to enforce the Content-length header; and (b) it'd hold the mutex for longer than necessary.

This commit also splits out the `HttpParseError` into several variants, which unfortunately makes this a breaking change. I think I can move that commit into its own PR if we want to get a minor rev out, but I don't think we care too much about that since this crate is pretty far to the edge of most dependency trees.

Adds a fuzz harness but doesn't integrate it into CI. Fixes a couple bugs I found while fuzzing locally.