### PR TITLE
simple_http: actually reuse sockets

### DIFF
--- a/src/simple_http.rs
+++ b/src/simple_http.rs
@@ -263,7 +263,9 @@ impl SimpleHttpTransport {
         // Attempt to parse the response. Don't check the HTTP error code until
         // after parsing, since Bitcoin Core will often return a descriptive JSON
         // error structure which is more useful than the error code.
-        match serde_json::from_reader(&mut reader) {
+        let mut response_buf = String::new();
+        reader.read_line(&mut response_buf)?;
+        match serde_json::from_str(&response_buf) {
             Ok(s) => {
                 if content_length.is_some() {
                     reader.bytes().count(); // consume any trailing bytes


### PR DESCRIPTION
serde_json::from_reader requires that the other side close the socket for it to complete. Therefore we were forcing the server to always close streams to us, never reusing any single sockets. In fact, it was more a burden because after the first request for every request we would have to call the request() function twice: once for it to notice that the socket was closed on the other side (receiving an EOF on line 202 and confusingly returning an error telling the HTTP header was malformed).

Instead, get back to what was previously used in previous versions: read a line from the stream (using '\n' to mark the end of the request instead of a connection close) and parse it afterward.

From https://docs.rs/serde_json/latest/serde_json/fn.from_reader.html:
> It is expected that the input stream ends after the deserialized object. If the stream does not end, such as in the case of a persistent socket connection, this function will not return. It is possible instead to deserialize from a prefix of an input stream without looking for EOF by managing your own [Deserializer](https://docs.rs/serde_json/latest/serde_json/struct.Deserializer.html).