### PR TITLE
Add `host` header to HTTP/1.1

### DIFF
--- a/src/simple_http.rs
+++ b/src/simple_http.rs
@@ -193,6 +193,9 @@ impl SimpleHttpTransport {
             write_sock.write_all(self.path.as_bytes())?;
             write_sock.write_all(b" HTTP/1.1\r\n")?;
             // Write headers
+            write_sock.write_all(b"host: ")?;
+            write_sock.write_all(self.addr.to_string().as_bytes())?;
+            write_sock.write_all(b"\r\n")?;
             write_sock.write_all(b"Content-Type: application/json\r\n")?;
             write_sock.write_all(b"Content-Length: ")?;
             write_sock.write_all(body.len().to_string().as_bytes())?;


### PR DESCRIPTION
The `host` header for HTTP1.1 must be sent according to [mozilla specs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) and [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-host-and-authority).

The absence of a host header breaks the compatibility with [jsonrpsee](https://github.com/paritytech/jsonrpsee) HTTP server for example.