### PR TITLE
Introduce SPDX license identifiers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,16 +1,4 @@
-// Rust JSON-RPC Library
-// Written in 2015 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Client support
 //!

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,4 @@
-// Rust JSON-RPC Library
-// Written in 2015 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Error handling
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,4 @@
-// Rust JSON-RPC Library
-// Written in 2015 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Rust JSON-RPC Library
 //!

--- a/src/simple_http.rs
+++ b/src/simple_http.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! This module implements a minimal and non standard conforming HTTP 1.0
 //! round-tripper that works with the bitcoind RPC server. This can be used
 //! if minimal dependencies are a goal and synchronous communication is ok.

--- a/src/simple_tcp.rs
+++ b/src/simple_tcp.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! This module implements a synchronous transport over a raw TcpListener. Note that
 //! it does not handle TCP over Unix Domain Sockets, see `simple_uds` for this.
 //!

--- a/src/simple_uds.rs
+++ b/src/simple_uds.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! This module implements a synchronous transport over a raw TcpListener.
 //!
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,16 +1,4 @@
-// Rust JSON-RPC Library
-// Written in 2019 by
-//   Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};


### PR DESCRIPTION
Licenses are boring as hell, so is are all the comments at the top of each file. This patch makes no comment on the merit of license comments in each file, rather this patch reduces the license comment to the minimum possible with no loss of meaning - an SPDX license identifier.

Note also please that we remove the "written by" comments as well for the following reasons (discussed recently on rust-bitcoin repo):

- they are not descriptive because many devs contributed
- they have a tendency to include the wrong date because of cut'n'pasta
- all this info is in the git history

ref: https://spdx.dev/ids/#how