### PR TITLE
Add rustdoc to pub crate export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,13 @@
 
 use serde::{Deserialize, Serialize};
 
-extern crate serde;
+/// Re-export `serde` crate.
+pub extern crate serde;
+/// Re-export `serde_json` crate.
 pub extern crate serde_json;
 
-#[cfg(feature = "base64-compat")]
+/// Re-export `base64` crate.
+#[cfg(feature = "base64")]
 pub extern crate base64;
 
 pub mod client;

--- a/src/simple_http.rs
+++ b/src/simple_http.rs
@@ -15,10 +15,6 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 use std::{error, fmt, io, net, num};
 
-use base64;
-use serde;
-use serde_json;
-
 use crate::client::Transport;
 use crate::{Request, Response};
 

--- a/src/simple_tcp.rs
+++ b/src/simple_tcp.rs
@@ -6,9 +6,6 @@
 
 use std::{error, fmt, io, net, time};
 
-use serde;
-use serde_json;
-
 use crate::client::Transport;
 use crate::{Request, Response};
 

--- a/src/simple_uds.rs
+++ b/src/simple_uds.rs
@@ -6,9 +6,6 @@
 use std::os::unix::net::UnixStream;
 use std::{error, fmt, io, path, time};
 
-use serde;
-use serde_json;
-
 use crate::client::Transport;
 use crate::{Request, Response};
 


### PR DESCRIPTION
Fix up the extern crates by doing:
    
- Remove edition 2015 use statements
- Feature guard `base64` re-export with the correct feature
- Re-export `serde` crate
- Add rustdoc to all three pub extern crates


