### PR TITLE
minreq_http: re-export minreq dependency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@ pub extern crate serde_json;
 #[cfg(feature = "base64")]
 pub extern crate base64;
 
+/// Re-export `minreq` crate if the feature is set.
+#[cfg(feature = "minreq")]
+pub extern crate minreq;
+
 pub mod client;
 pub mod error;
 pub mod http;


### PR DESCRIPTION
So that downstream users can match against error variants.

I had to add minreq as a direct dependency to my project. Since we are using `minreq::Error` in one variant of `minreq_http::Error`, better let users directly access it as `minreq_http::minreq::Error`?