### PR TITLE
Release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.16.0 - 2023-06-29
+
+* Re-export the `minreq` crate when the feature is set
+  [#102](https://github.com/apoelstra/rust-jsonrpc/pull/102)
+* Don't treat HTTP errors with no JSON as JSON parsing errors
+  [#103](https://github.com/apoelstra/rust-jsonrpc/pull/103)
+
 # 0.15.0 - 2023-05-28
 
 * Add new transport that uses `minreq`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/apoelstra/rust-jsonrpc/"

--- a/src/http/minreq_http.rs
+++ b/src/http/minreq_http.rs
@@ -190,6 +190,7 @@ impl error::Error for HttpError {}
 /// Error that can happen when sending requests. In case of error, a JSON error is returned if the
 /// body of the response could be parsed as such. Otherwise, an HTTP error is returned containing
 /// the status code and the raw body.
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum Error {
     /// JSON parsing error.

--- a/src/http/simple_http.rs
+++ b/src/http/simple_http.rs
@@ -663,6 +663,7 @@ mod impls {
 #[cfg(test)]
 mod tests {
     use std::net;
+    #[cfg(feature = "proxy")]
     use std::str::FromStr;
 
     use super::*;


### PR DESCRIPTION
To make #103 and #102 available downstream. Note i've successfully tested #103 in my software (detect and retry requests to bitcoind upon hitting a transient workqueue exceeded error). 

Updating the Error enum for minreq_http is an API break, so bump the major version.