### PR TITLE
Bump version to 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.17.0 - 2023-06-29
+# 0.17.0 - 2023-12-22
 
 * `params` field in `Request` changed to a generic `RawValue` instead of an array.
   [#108](https://github.com/apoelstra/rust-jsonrpc/pull/108)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/apoelstra/rust-jsonrpc/"


### PR DESCRIPTION
changelog was already good (just fixed the date)

close #110 