### PR TITLE
fix small copy/paste comment

### DIFF
--- a/src/simple_uds.rs
+++ b/src/simple_uds.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! This module implements a synchronous transport over a raw [`std::net::TcpListener`].
+//! This module implements a synchronous transport over a raw [`std::net::UnixStream`].
 
 use std::os::unix::net::UnixStream;
 use std::{error, fmt, io, path, time};

--- a/src/simple_uds.rs
+++ b/src/simple_uds.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! This module implements a synchronous transport over a raw [`std::net::UnixStream`].
+//! This module implements a synchronous transport over a raw [`std::os::unix::net::UnixStream`].
 
 use std::os::unix::net::UnixStream;
 use std::{error, fmt, io, path, time};


### PR DESCRIPTION
The UNIX Stream example header comment had the same top comment mentioning `std::net::TcpListener`